### PR TITLE
Fix _config.yml url and baseurl misconfiguration

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,11 +2,9 @@ remote_theme: pages-themes/cayman@v0.2.0
 title: "Stories from an Azure Developer"
 twitter_username: rich_ross
 github_username: richross
-#   Write an awesome description for your new site here. You can edit this
-#   line in _config.yml. It will appear in your document head meta (for
-#   Google search results) and in your feed.xml site description.
-baseurl: "/" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+description: "Stories from an Azure Developer"
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "https://richross.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Fixes #13

## Changes

- Set `url` to `"https://richross.github.io"` (was empty string)
- Set `baseurl` to `""` (was `"/"`, incorrect for a user GitHub Pages site)
- Added `description` field: `"Stories from an Azure Developer"`

## Impact

These fixes resolve broken canonical URLs from `jekyll-seo-tag`, the broken feed URL from `jekyll-feed`, and any empty `{{ site.url }}` references throughout the site.